### PR TITLE
Quote matrix versions (because YAML is ambiguous)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test macOS
     strategy:
       matrix:
-        macVersion: [11.0, 10.15]
+        macVersion: ["11.0", "10.15"]
 
     runs-on: macos-${{ matrix.macVersion }}
 
@@ -28,7 +28,7 @@ jobs:
     name: Test Ubuntu
     strategy:
       matrix:
-        ubuntuVersion: [18.04, 20.04]
+        ubuntuVersion: ["18.04", "20.04"]
 
     runs-on: ubuntu-${{ matrix.ubuntuVersion }}
 


### PR DESCRIPTION
YAML parses these versions as floating point values, and then reformats `11.0` as `11` in string interpolation. 😑